### PR TITLE
Fix for resolver crash when profile is empty or not valid JSON

### DIFF
--- a/server/resolver.py
+++ b/server/resolver.py
@@ -159,8 +159,7 @@ def get_user_profile(username):
         profile = full_profile_mem(key)
 
         if not profile:
-            #abort(404)
-            print "abort"
+            abort(404)
         else:
             info['profile'] = profile
             info['verifications'] = profile_to_proofs(profile, username)


### PR DESCRIPTION
Fixes problem where resolver crashes if user profile is empty or does not contain valid JSON.

To replicate issue: try to resolve the Openname allie (as of block 224798)

![screen shot 2015-04-03 at 3 34 13 am](https://cloud.githubusercontent.com/assets/597182/6971908/70754b0c-d9b2-11e4-9c0a-3ebb94aa5f26.png)

Onename's json profile server also crashes:
https://onename.com/allie.json

![screen shot 2015-04-03 at 3 30 46 am](https://cloud.githubusercontent.com/assets/597182/6971845/066c37fc-d9b2-11e4-90cd-9d0d695e3275.png)

Traceback:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/root/resolver/server/crossdomain.py", line 37, in wrapped_function
    resp = make_response(f(*args, **kwargs))
  File "/root/resolver/server/resolver.py", line 185, in get_users
    info = get_user_profile(usernames)
  File "/root/resolver/server/resolver.py", line 156, in get_user_profile
    profile = full_profile_mem(key)
  File "/root/resolver/server/resolver.py", line 70, in full_profile_mem
    check_profile = name_show_mem(key)
  File "/root/resolver/server/resolver.py", line 62, in name_show_mem
    info['value'] = json.loads(cache_reply)
  File "/usr/lib/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```
