### PR TITLE
Fix refresh names infinite loop

### DIFF
--- a/resolver/refresh_names.py
+++ b/resolver/refresh_names.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         if len(new_names) == 0:
             break
 
-        #Check for blockstack errors
+        # check for blockstack errors
         if len(new_names) == 1 and "error" in new_names:
             print "Blockstack error: " + new_names["error"]
             break

--- a/resolver/refresh_names.py
+++ b/resolver/refresh_names.py
@@ -42,6 +42,11 @@ if __name__ == "__main__":
         if len(new_names) == 0:
             break
 
+        #Check for blockstack errors
+        if len(new_names) == 1 and "error" in new_names:
+            print "Blockstack error: " + new_names["error"]
+            break
+
         total_names += new_names
         offset += count
 


### PR DESCRIPTION
`refresh_names.py` enters an infinite loop when blockstack returns an error.

For example, when blockstack server is indexing the blockchain, `bs_client.get_all_names(offset, count)` always returns `{'error': 'Indexing blockchain`}` which the script treats as a single name. The break condition of no new names is never met and the while loops continues forever.

This pull requests checks for an error message, displays the error messages, and breaks out of the loop.



